### PR TITLE
fix: use ElementCSSInlineStyle in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'svelte-css-vars' {
   export function update(new_props: Record<string, any>);
 
-  function apply(node: HTMLElement, props: Record<string, any>);
+  function apply(node: ElementCSSInlineStyle, props: Record<string, any>);
 
   export default apply;
 }


### PR DESCRIPTION
`ElementCSSInline` (interface) should match to any element (not just `HTMLElements`) that can contain an inline style

This resolves errors with svelte-check / VSCode when using `svelte-css-vars` on an `<svg>` element